### PR TITLE
Multiline inputs as option for custom fields

### DIFF
--- a/app.css
+++ b/app.css
@@ -1689,6 +1689,15 @@ pre {
         padding-top: 0.5rem;
         line-height: 1.5;
       }
+
+      .form__input--textarea-author-field {
+        resize: vertical;
+        min-height: 5rem;
+        padding-top: 0.5rem;
+        line-height: 1.5;
+        width: 100%
+      }
+
       .form__input--textarea-no-min-height {
         resize: vertical;
         height: inherit;

--- a/index.html
+++ b/index.html
@@ -35,9 +35,9 @@
                 "questionType": "presenting"
             }, {
                 "id": 5,
-                "title": "email",
-                "description": "add your email here",
-                "inputType": "string",
+                "title": "Description of the authors involvement",
+                "description": "add text",
+                "inputType": "longString",
                 "questionType": "custom",
                 "mandatory": "on"
             }, {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-authors",
-  "version": "2.0.8",
+  "version": "2.0.9",
   "description": "To open compiled code open index.html",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-authors",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "To open compiled code open index.html",
   "main": "index.js",
   "scripts": {

--- a/src/AuthorsView.elm
+++ b/src/AuthorsView.elm
@@ -68,23 +68,23 @@ renderAuthor model ( author, index ) =
                 div []
                     []
 
-
         isFullWidth authorField =
-          authorField.inputType == LongStringType
+            authorField.inputType == LongStringType
 
+        -- needs to filter out the full width responses from the model.authorFields
+        fullWidthAuthorFields =
+            List.filter isFullWidth model.authorFields
 
--- needs to filter out the full width responses from the model.authorFields
-        fullWidthAuthorFields = List.filter isFullWidth model.authorFields
-        authorFields =  List.filter (not << isFullWidth) model.authorFields
+        authorFields =
+            List.filter (not << isFullWidth) model.authorFields
 
         chunkifiedAuthorFields =
             chunk 3 authorFields
 
         fieldsHtml =
-          List.append
-          (List.map (renderFieldResponsesLine model author.authorFieldResponses author.id) chunkifiedAuthorFields)
-          (List.map (renderFullWidthFieldResponse author.authorFieldResponses author.id) fullWidthAuthorFields)
-
+            List.append
+                (List.map (renderFieldResponsesLine model author.authorFieldResponses author.id) chunkifiedAuthorFields)
+                (List.map (renderFullWidthFieldResponse author.authorFieldResponses author.id) fullWidthAuthorFields)
     in
         div [ class "author aa" ]
             [ div [ class "aa__dividing-title" ]
@@ -114,7 +114,6 @@ renderAuthor model ( author, index ) =
 
 renderFullWidthFieldResponse authorFieldResponses authorId authorField =
     let
-
         authorFieldResponse =
             authorFieldResponses
                 |> List.filter (\a -> a.authorFieldId == authorField.id)
@@ -122,14 +121,15 @@ renderFullWidthFieldResponse authorFieldResponses authorId authorField =
                 |> Maybe.withDefault defaultAuthorFieldResponse1
 
         requiredText =
-          if authorField.mandatory == "on" then
-            " (Required)"
-          else
-            ""
+            if authorField.mandatory == "on" then
+                " (Required)"
+            else
+                ""
 
-        maxCharactersString = " (Max 500 Characters)"
+        maxCharactersString =
+            " (Max 500 Characters)"
 
-        labelX =
+        label =
             if authorField.description /= "" then
                 label
                     [ class "form__label tooltip"
@@ -141,29 +141,29 @@ renderFullWidthFieldResponse authorFieldResponses authorId authorField =
             else
                 label
                     [ class "form__label" ]
-                    [ text (String.append authorField.title requiredText)]
+                    [ text (String.append authorField.title requiredText) ]
 
         inputHtml =
             div [ class "aa__field aa__field--tablecell" ]
-                [ labelX
+                [ label
                 , textarea
-                    [
-                    rows 5
+                    [ rows 5
                     , maxlength 500
                     , class "form__input--textarea-author-field"
                     , onInput (UpdateAuthorFieldString authorId authorField.id)
                     , value authorFieldResponse.value
                     ]
-                    [
-                  ]
+                    []
                 ]
     in
-    div [ class "aa__sub-section aa__sub-section--table" ]
-        [inputHtml]
+        div [ class "aa__sub-section aa__sub-section--table" ]
+            [ inputHtml ]
+
 
 renderFieldResponsesLine model authorFieldResponses authorId authorFieldLine =
     div [ class "aa__sub-section aa__sub-section--table" ]
         (List.map (renderFieldResponse model authorFieldResponses authorId) authorFieldLine)
+
 
 renderFieldResponse model authorFieldResponses authorId authorField =
     let
@@ -173,12 +173,11 @@ renderFieldResponse model authorFieldResponses authorId authorField =
                 |> List.head
                 |> Maybe.withDefault defaultAuthorFieldResponse1
 
-
         requiredText =
-          if authorField.mandatory == "on" then
-            " (Required)"
-          else
-            ""
+            if authorField.mandatory == "on" then
+                " (Required)"
+            else
+                ""
 
         labelX =
             if authorField.description /= "" then
@@ -192,7 +191,7 @@ renderFieldResponse model authorFieldResponses authorId authorField =
             else
                 label
                     [ class "form__label" ]
-                    [ text (String.append authorField.title requiredText)]
+                    [ text (String.append authorField.title requiredText) ]
 
         inputHtml =
             if authorField.inputType == BoolType then
@@ -217,13 +216,13 @@ renderFieldResponse model authorFieldResponses authorId authorField =
                         , id (authorField.title)
                         , class "form__input"
                         , checked (authorFieldResponse.value == "true")
-                          -- if one of the other(!) inputs with SinglePresenterType === checked then disable
+
+                        -- if one of the other(!) inputs with SinglePresenterType === checked then disable
                         , disabled (disableThePresentingCheckbox model (authorFieldResponse.value == "true") authorField.id)
                         , onClick (UpdateAuthorFieldBool authorId authorField.id)
                         ]
                         []
                     ]
-
             else
                 div [ class "aa__field aa__field--tablecell" ]
                     [ labelX
@@ -296,12 +295,11 @@ renderAffiliations model affiliations authorId =
 renderAffiliation : Model -> Int -> ( Affiliation, Int ) -> Html Msg
 renderAffiliation model authorId ( affiliation, index ) =
     let
-
         institutionRequiredText =
-          if model.mandatoryInstitution then
-            "Institution (Required)"
-          else
-            "Institution"
+            if model.mandatoryInstitution then
+                "Institution (Required)"
+            else
+                "Institution"
 
         institutionDiv =
             if model.showInstitution then
@@ -324,10 +322,10 @@ renderAffiliation model authorId ( affiliation, index ) =
                 text ""
 
         cityRequiredText =
-          if model.mandatoryCity then
-            "City (Required)"
-          else
-            "City"
+            if model.mandatoryCity then
+                "City (Required)"
+            else
+                "City"
 
         cityDiv =
             if model.showCity then
@@ -349,10 +347,10 @@ renderAffiliation model authorId ( affiliation, index ) =
                 text ""
 
         stateRequiredText =
-          if model.mandatoryState then
-            "State (Required)"
-          else
-            "State"
+            if model.mandatoryState then
+                "State (Required)"
+            else
+                "State"
 
         stateDiv =
             if model.showState then
@@ -374,16 +372,16 @@ renderAffiliation model authorId ( affiliation, index ) =
                 text ""
 
         countryRequiredText =
-          if model.mandatoryCountry then
-            "Country (Required)"
-          else
-            "Country"
+            if model.mandatoryCountry then
+                "Country (Required)"
+            else
+                "Country"
 
         countryDiv =
             if model.showCountry then
                 div [ class "aa__field aa__field--tablecell" ]
                     [ label [ class "form__label" ]
-                    [ text countryRequiredText ]
+                        [ text countryRequiredText ]
                     , select
                         [ class "country form__input form__input--dropdown"
                         , list "countries-list"

--- a/src/AuthorsView.elm
+++ b/src/AuthorsView.elm
@@ -68,8 +68,23 @@ renderAuthor model ( author, index ) =
                 div []
                     []
 
+
+        isFullWidth authorField =
+          authorField.inputType == LongStringType
+
+
+-- needs to filter out the full width responses from the model.authorFields
+        fullWidthAuthorFields = List.filter isFullWidth model.authorFields
+        authorFields =  List.filter (not << isFullWidth) model.authorFields
+
         chunkifiedAuthorFields =
-            chunk 3 model.authorFields
+            chunk 3 authorFields
+
+        fieldsHtml =
+          List.append
+          (List.map (renderFieldResponsesLine model author.authorFieldResponses author.id) chunkifiedAuthorFields)
+          (List.map (renderFullWidthFieldResponse author.authorFieldResponses author.id) fullWidthAuthorFields)
+
     in
         div [ class "author aa" ]
             [ div [ class "aa__dividing-title" ]
@@ -83,7 +98,8 @@ renderAuthor model ( author, index ) =
                 [ text ("Remove Author") ]
             , div [ class "aa__sub-section aa__sub-section--table" ]
                 --for each of the authorFields we want to add a div like this:
-                [ div [ class "aa__field aa__field--tablecell" ] (List.map (renderFieldResponsesLine model author.authorFieldResponses author.id) chunkifiedAuthorFields)
+                [ div [ class "aa__field aa__field--tablecell" ]
+                    fieldsHtml
                 ]
             , div [ class "aa__inner-container" ]
                 [ div [ class "aa__dividing-title aa__dividing-title--linebreak" ]
@@ -96,12 +112,57 @@ renderAuthor model ( author, index ) =
             ]
 
 
+renderFullWidthFieldResponse authorFieldResponses authorId authorField =
+    let
+
+        authorFieldResponse =
+            authorFieldResponses
+                |> List.filter (\a -> a.authorFieldId == authorField.id)
+                |> List.head
+                |> Maybe.withDefault defaultAuthorFieldResponse1
+
+        requiredText =
+          if authorField.mandatory == "on" then
+            " (Required)"
+          else
+            ""
+
+        labelX =
+            if authorField.description /= "" then
+                label
+                    [ class "form__label tooltip"
+                    , for (authorField.title)
+                    ]
+                    [ text (String.append authorField.title requiredText)
+                    , span [ class "tooltip__box" ] [ text authorField.description ]
+                    ]
+            else
+                label
+                    [ class "form__label" ]
+                    [ text (String.append authorField.title requiredText)]
+
+        inputHtml =
+            div [ class "aa__field aa__field--tablecell" ]
+                [ labelX
+                , textarea
+                    [
+                    rows 5
+                    , class "form__input--textarea-author-field"
+                    , onInput (UpdateAuthorFieldString authorId authorField.id)
+                    , value authorFieldResponse.value
+                    ]
+                    [
+                  ]
+                ]
+    in
+    div [ class "aa__sub-section aa__sub-section--table" ]
+        [inputHtml]
+
 renderFieldResponsesLine model authorFieldResponses authorId authorFieldLine =
     div [ class "aa__sub-section aa__sub-section--table" ]
-        (List.map (renderFieldResponses model authorFieldResponses authorId) authorFieldLine)
+        (List.map (renderFieldResponse model authorFieldResponses authorId) authorFieldLine)
 
-
-renderFieldResponses model authorFieldResponses authorId authorField =
+renderFieldResponse model authorFieldResponses authorId authorField =
     let
         authorFieldResponse =
             authorFieldResponses
@@ -159,6 +220,7 @@ renderFieldResponses model authorFieldResponses authorId authorField =
                         ]
                         []
                     ]
+
             else
                 div [ class "aa__field aa__field--tablecell" ]
                     [ labelX

--- a/src/AuthorsView.elm
+++ b/src/AuthorsView.elm
@@ -127,13 +127,15 @@ renderFullWidthFieldResponse authorFieldResponses authorId authorField =
           else
             ""
 
+        maxCharactersString = " (Max 500 Characters)"
+
         labelX =
             if authorField.description /= "" then
                 label
                     [ class "form__label tooltip"
                     , for (authorField.title)
                     ]
-                    [ text (String.append authorField.title requiredText)
+                    [ text (authorField.title ++ maxCharactersString ++ requiredText)
                     , span [ class "tooltip__box" ] [ text authorField.description ]
                     ]
             else
@@ -147,6 +149,7 @@ renderFullWidthFieldResponse authorFieldResponses authorId authorField =
                 , textarea
                     [
                     rows 5
+                    , maxlength 500
                     , class "form__input--textarea-author-field"
                     , onInput (UpdateAuthorFieldString authorId authorField.id)
                     , value authorFieldResponse.value

--- a/src/Decoders.elm
+++ b/src/Decoders.elm
@@ -62,6 +62,9 @@ fieldTypeHelper inputType =
         "singlePresenter" ->
             SinglePresenterType
 
+        "longString" ->
+            LongStringType
+
         _ ->
             StringType
 

--- a/src/MainModel.elm
+++ b/src/MainModel.elm
@@ -30,7 +30,7 @@ type alias Flags =
     , showInstitution : Bool
     , showCity : Bool
     , showState : Bool
-    , showCountry : Bool  
+    , showCountry : Bool
     , mandatoryInstitution : Bool
     , mandatoryCity : Bool
     , mandatoryState : Bool
@@ -64,6 +64,7 @@ initialModel =
 type FieldType
     = BoolType
     | StringType
+    | LongStringType
     | SinglePresenterType
 
 


### PR DESCRIPTION
Issue #3290 on the main app, allows users to add a multiline text area as a custom author field input.