### PR TITLE
Allow submitters to add et al to the list of authors

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-authors",
-  "version": "3.1.0",
+  "version": "3.1.1",
   "description": "To open compiled code open index.html",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "elm-authors",
-  "version": "3.0.1",
+  "version": "3.1.0",
   "description": "To open compiled code open index.html",
   "main": "index.js",
   "scripts": {

--- a/src/AuthorsView.elm
+++ b/src/AuthorsView.elm
@@ -39,7 +39,7 @@ renderAuthors model =
         addAuthorButton =
             if model.authorLimit > (List.length model.authors) then
                 div [ class "button button--secondary aa__add-author-button", onClick AddAuthor ] [ text "Add Another Author" ]
-            else
+            else if model.hasEtAlToggle then
                 div []
                     [ label
                       [class "form__label"]
@@ -52,6 +52,9 @@ renderAuthors model =
                       ]
                       []
                     ]
+            else
+                div []
+                []
     in
         div [ class model.class ]
             [ div [ class "" ] (List.map (renderAuthor model) authorIndexTuples)

--- a/src/AuthorsView.elm
+++ b/src/AuthorsView.elm
@@ -41,7 +41,17 @@ renderAuthors model =
                 div [ class "button button--secondary aa__add-author-button", onClick AddAuthor ] [ text "Add Another Author" ]
             else
                 div []
-                    []
+                    [ label
+                      [class "form__label"]
+                      [text model.etAlQuestionText]
+                    , input
+                      [type_ "checkbox"
+                      , class "form__input"
+                      , checked model.etAl
+                      , name "etAl"
+                      ]
+                      []
+                    ]
     in
         div [ class model.class ]
             [ div [ class "" ] (List.map (renderAuthor model) authorIndexTuples)

--- a/src/Main.elm
+++ b/src/Main.elm
@@ -22,8 +22,10 @@ init flags =
         authors =
             Decoders.authors flags.authorsList
 
-        { affiliationLimit, authorLimit, showInstitution, showCity, showState, showCountry, mandatoryInstitution, mandatoryCity, mandatoryState, mandatoryCountry, class, institutionLabel, cityLabel, stateLabel, countryLabel } =
-            flags
+        { affiliationLimit, authorLimit, showInstitution, showCity, showState, showCountry, mandatoryInstitution,
+          mandatoryCity, mandatoryState, mandatoryCountry, class, institutionLabel, cityLabel, stateLabel, countryLabel,
+          etAl, hasEtAlToggle } =
+          flags
 
         authorsWithBlankResponses =
             List.map (addBlankResponsesToAuthor authorFields) authors
@@ -66,6 +68,9 @@ init flags =
                 , countryLabel = countryLabel
                 , class = class
                 , countries = flags.countries
+                , etAl = flags.etAl
+                , hasEtAlToggle = flags.hasEtAlToggle
+                , etAlQuestionText = flags.etAlQuestionText
             }
     in
         ( model, Cmd.none )

--- a/src/MainModel.elm
+++ b/src/MainModel.elm
@@ -24,6 +24,9 @@ type alias Model =
     , stateLabel : String
     , countryLabel : String
     , countries : List String
+    , etAl : Bool
+    , hasEtAlToggle : Bool
+    , etAlQuestionText : String
     }
 
 
@@ -46,6 +49,9 @@ type alias Flags =
     , stateLabel : String
     , countryLabel : String
     , countries : List String
+    , etAl : Bool
+    , hasEtAlToggle : Bool
+    , etAlQuestionText : String
     }
 
 
@@ -73,6 +79,10 @@ initialModel =
     , stateLabel = "State"
     , countryLabel = "Country"
     , countries = []
+    , etAl = False
+    , hasEtAlToggle = False
+    , etAlQuestionText = "Check this box to add et al after the list of authors"
+
     }
 
 


### PR DESCRIPTION
Issue #4304 on the main app. Allow submitters to add et al to the list of authors once they have reached their limit of authors